### PR TITLE
feat: [#9] username password 로그인 구현

### DIFF
--- a/src/main/java/com/example/member/controller/MemberController.java
+++ b/src/main/java/com/example/member/controller/MemberController.java
@@ -2,15 +2,17 @@ package com.example.member.controller;
 
 import com.example.member.dto.MemberRegisterRequestDto;
 import com.example.member.service.MemberService;
+import com.example.security.authentication.AuthenticatedMember;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RestController
 @RequestMapping("/members")
 @RequiredArgsConstructor
@@ -23,4 +25,12 @@ public class MemberController {
         memberService.registerMember(memberRegisterRequestDto);
         return new ResponseEntity(HttpStatus.CREATED);
     }
+
+    @GetMapping("/info")
+    public void infoMember(@AuthenticationPrincipal AuthenticatedMember authenticatedMember) {
+        AuthenticatedMember member = (AuthenticatedMember) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        log.info("member -> {}", member.toString());
+        log.info("authenticatedMember -> {}", authenticatedMember.toString());
+    }
+
 }

--- a/src/main/java/com/example/member/entity/Member.java
+++ b/src/main/java/com/example/member/entity/Member.java
@@ -35,12 +35,13 @@ public class Member {
 
     public static Member fromMemberRegisterRequestDto(MemberRegisterRequestDto memberRegisterRequestDto) {
         Member member = new Member();
-
         member.username = memberRegisterRequestDto.getUsername();
-        member.password = memberRegisterRequestDto.getPassword();
         member.nickname = memberRegisterRequestDto.getNickname();
-
         return member;
+    }
+
+    public void setEncodedPassword(String encodedPassword) {
+        this.password = encodedPassword;
     }
 
     public void changeNickname(String nickname) {

--- a/src/main/java/com/example/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/member/repository/MemberRepository.java
@@ -4,7 +4,9 @@ import com.example.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
-
+    Optional<Member> findByUsername(String username);
 }

--- a/src/main/java/com/example/member/service/MemberService.java
+++ b/src/main/java/com/example/member/service/MemberService.java
@@ -4,16 +4,19 @@ import com.example.member.dto.MemberRegisterRequestDto;
 import com.example.member.entity.Member;
 import com.example.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 
+    private final PasswordEncoder passwordEncoder;
     private final MemberRepository memberRepository;
 
     public void registerMember(MemberRegisterRequestDto memberRegisterRequestDto) {
         Member member = Member.fromMemberRegisterRequestDto(memberRegisterRequestDto);
+        member.setEncodedPassword(passwordEncoder.encode(memberRegisterRequestDto.getPassword()));
         memberRepository.save(member);
     }
 

--- a/src/main/java/com/example/security/SecurityConfig.java
+++ b/src/main/java/com/example/security/SecurityConfig.java
@@ -1,0 +1,63 @@
+package com.example.security;
+
+import com.example.security.authentication.LoginProcessingFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    @Order(0)
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .httpBasic(Customizer.withDefaults())
+                .formLogin(login -> login.disable()) // 폼로그인 비허용
+                .authorizeHttpRequests(authorize -> authorize
+                        .anyRequest().permitAll())
+                .securityContext(securityContext -> new HttpSessionSecurityContextRepository());
+
+        return http.build();
+    }
+
+    @Bean
+    @Order(1)
+    public SecurityFilterChain addCustomFilters(HttpSecurity http,
+                                                LoginProcessingFilter loginProcessingFilter) throws Exception {
+        http
+                .addFilterAt(loginProcessingFilter, UsernamePasswordAuthenticationFilter.class); // 로그인 필터 등록
+
+        return http.build();
+    }
+
+    @Bean
+    public LoginProcessingFilter loginProcessingFilter(AuthenticationManager authenticationManager) {
+        LoginProcessingFilter loginProcessingFilter = new LoginProcessingFilter();
+        loginProcessingFilter.setAuthenticationManager(authenticationManager);
+        return loginProcessingFilter;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationProvider authenticationProvider) {
+        return new ProviderManager(authenticationProvider);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}

--- a/src/main/java/com/example/security/SecurityConfig.java
+++ b/src/main/java/com/example/security/SecurityConfig.java
@@ -28,7 +28,8 @@ public class SecurityConfig {
                 .httpBasic(Customizer.withDefaults())
                 .formLogin(login -> login.disable()) // 폼로그인 비허용
                 .authorizeHttpRequests(authorize -> authorize
-                        .anyRequest().permitAll())
+                        .requestMatchers("/members/login", "members/register").permitAll() // 로그인, 회원가입 url만 허용
+                        .anyRequest().authenticated())
                 .securityContext(securityContext -> new HttpSessionSecurityContextRepository());
 
         return http.build();

--- a/src/main/java/com/example/security/authentication/AuthenticatedMember.java
+++ b/src/main/java/com/example/security/authentication/AuthenticatedMember.java
@@ -27,4 +27,10 @@ public class AuthenticatedMember {
         return Objects.hash(memberId, nickName);
     }
 
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("memberId: ").append(memberId).append(", nickname: ").append(nickName);
+        return sb.toString();
+    }
 }

--- a/src/main/java/com/example/security/authentication/AuthenticatedMember.java
+++ b/src/main/java/com/example/security/authentication/AuthenticatedMember.java
@@ -1,0 +1,30 @@
+package com.example.security.authentication;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Objects;
+
+/**
+ * Authentication의  Principal에 저장될 Custom principal(인증객체)
+ */
+@Getter
+@AllArgsConstructor
+public class AuthenticatedMember {
+
+    private Long memberId;
+    private String nickName;
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (this.hashCode() != obj.hashCode()) return false;
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(memberId, nickName);
+    }
+
+}

--- a/src/main/java/com/example/security/authentication/LoginProcessingFilter.java
+++ b/src/main/java/com/example/security/authentication/LoginProcessingFilter.java
@@ -1,0 +1,65 @@
+package com.example.security.authentication;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.web.context.SecurityContextRepository;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.util.StreamUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+public class LoginProcessingFilter extends AbstractAuthenticationProcessingFilter {
+
+    private SecurityContextRepository securityContextRepository = new HttpSessionSecurityContextRepository();
+
+    public LoginProcessingFilter() {
+        super(new AntPathRequestMatcher("/members/login")); // "/members/login" 요청에 Filter를 적용
+    }
+
+    @SneakyThrows
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        // 1. HTTP 요청 바디 json을 읽어 DTO로 변환
+        UsernamePasswordLoginDto usernamePasswordLoginDto = jsonToUsernamePasswordLoginDto(request);
+
+        // 2. 인증처리 전의 Authentication 객체를 생성
+        MemberAuthenticationToken authRequest =
+                MemberAuthenticationToken.unauthenticated(usernamePasswordLoginDto);
+
+        // 3. AuthenticationManager에게 인증처리를 위임
+        return super.getAuthenticationManager().authenticate(authRequest);
+    }
+
+    private UsernamePasswordLoginDto jsonToUsernamePasswordLoginDto(HttpServletRequest request) throws IOException {
+        ServletInputStream inputStream = request.getInputStream();
+        String usernamePasswordJson = StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.readValue(usernamePasswordJson, UsernamePasswordLoginDto.class);
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) {
+        // 1. 비어있는 SecurityContext를 생성
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        // 2. 인증처리 완료된 Authentication 객체를 SecurityContext에 등록
+        context.setAuthentication(authResult);
+
+        this.securityContextRepository.saveContext(context, request, response);
+    }
+
+}

--- a/src/main/java/com/example/security/authentication/MemberAuthenticationToken.java
+++ b/src/main/java/com/example/security/authentication/MemberAuthenticationToken.java
@@ -1,0 +1,45 @@
+package com.example.security.authentication;
+
+import lombok.Getter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+
+@Getter
+public class MemberAuthenticationToken extends AbstractAuthenticationToken {
+
+    private Object principal;
+    private String credential;
+
+    private MemberAuthenticationToken(String username, String password) {
+        super(null);
+        this.principal = username;
+        this.credential = password;
+        this.setAuthenticated(false);
+    }
+
+    private MemberAuthenticationToken(Object principal, String credential) {
+        super(null);
+        this.principal = principal;
+        this.credential = null;
+        this.setAuthenticated(true);
+    }
+
+    // 인증처리 전
+    public static MemberAuthenticationToken unauthenticated(UsernamePasswordLoginDto loginDto) {
+        return new MemberAuthenticationToken(loginDto.getUsername(), loginDto.getPassword());
+    }
+
+    // 인증처리 후
+    public static MemberAuthenticationToken authenticated(AuthenticatedMember principal) {
+        return new MemberAuthenticationToken(principal, null);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return principal;
+    }
+}

--- a/src/main/java/com/example/security/authentication/UsernamePasswordAuthenticationProvider.java
+++ b/src/main/java/com/example/security/authentication/UsernamePasswordAuthenticationProvider.java
@@ -1,0 +1,48 @@
+package com.example.security.authentication;
+
+import com.example.member.entity.Member;
+import com.example.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UsernamePasswordAuthenticationProvider implements AuthenticationProvider {
+
+    private final PasswordEncoder passwordEncoder;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        // 1. DB에서 username으로 Member를 찾음
+        MemberAuthenticationToken authenticationToken = (MemberAuthenticationToken) authentication;
+        String username = String.valueOf(authenticationToken.getPrincipal());
+
+        Member findMember = memberRepository.findByUsername(username).orElseGet(()-> {
+                    throw new UsernameNotFoundException("아이디를 찾을 수 없습니다.");
+        });
+
+        // 2. DB와 password가 일치하는지 검증
+        String password = authenticationToken.getCredential();
+        if (!passwordEncoder.matches(password, findMember.getPassword())) {
+            throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
+        }
+
+        // 3. 인증 성공 시 Authentication 토큰 생성
+        AuthenticatedMember authenticatedMember = new AuthenticatedMember(findMember.getId(), findMember.getNickname());
+        return MemberAuthenticationToken.authenticated(authenticatedMember);
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return MemberAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/src/main/java/com/example/security/authentication/UsernamePasswordAuthenticationProvider.java
+++ b/src/main/java/com/example/security/authentication/UsernamePasswordAuthenticationProvider.java
@@ -26,9 +26,8 @@ public class UsernamePasswordAuthenticationProvider implements AuthenticationPro
         MemberAuthenticationToken authenticationToken = (MemberAuthenticationToken) authentication;
         String username = String.valueOf(authenticationToken.getPrincipal());
 
-        Member findMember = memberRepository.findByUsername(username).orElseGet(()-> {
-                    throw new UsernameNotFoundException("아이디를 찾을 수 없습니다.");
-        });
+        Member findMember = memberRepository.findByUsername(username).orElseThrow(
+                ()-> new UsernameNotFoundException("아이디를 찾을 수 없습니다."));
 
         // 2. DB와 password가 일치하는지 검증
         String password = authenticationToken.getCredential();

--- a/src/main/java/com/example/security/authentication/UsernamePasswordLoginDto.java
+++ b/src/main/java/com/example/security/authentication/UsernamePasswordLoginDto.java
@@ -1,0 +1,18 @@
+package com.example.security.authentication;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UsernamePasswordLoginDto {
+    private String username;
+    private String password;
+
+    @Builder
+    public UsernamePasswordLoginDto(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+}

--- a/src/test/java/com/example/security/authentication/AuthenticatedMemberTest.java
+++ b/src/test/java/com/example/security/authentication/AuthenticatedMemberTest.java
@@ -1,0 +1,30 @@
+package com.example.security.authentication;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AuthenticatedMemberTest {
+
+    @Test
+    @DisplayName("AuthenticatedMember equals 테스트")
+    void equalsTest() {
+        // given
+        AuthenticatedMember member1 = new AuthenticatedMember(1L, "nickname");
+        AuthenticatedMember member2 = new AuthenticatedMember(2L, "nickname");
+
+        // then
+        Assertions.assertThat(member1.equals(member2)).isFalse();
+    }
+
+    @Test
+    @DisplayName("AuthenticatedMember hashCode 테스트")
+    void hashCodeTest() {
+        // given
+        AuthenticatedMember member1 = new AuthenticatedMember(1L, "nickname");
+        AuthenticatedMember member2 = new AuthenticatedMember(1L, "nickname");
+
+        // then
+        Assertions.assertThat(member1.hashCode()).isEqualTo(member2.hashCode());
+    }
+}


### PR DESCRIPTION
## Issue Number
Resolves #9 


## 변경사항
- 로그인 필터 등록
- 인증객체(MemberAuthenticationToken, AuthenticatedMember) 구현

## 주요 클래스 소개
1. `LoginProcessingFilter`
   - 인증 처리의 시작지점.
   - `attemptAuthentication` `successfulAuthentication` 메서드를 가집니다.
2. `UsernamePasswordAuthenticationProvider`
   - 실질적으로 인증처리를 수행하는 클래스.
3. `UsernamePasswordLoginDto`
   - 사용자가 입력한 username과 password가 담기는 객체.
4. `MemberAuthenticationToken`
   - 인증처리 전에는 principal과 credential에 각각 사용자가 입력한 username과 password가 담깁니다.
   - 인증처리가 완료된 후에는 principal에 `AuthenticatedMember`가, credential에 null이 담깁니다.
5. `AuthenticatedMember`: 인증된 회원 객체. memberId와 nickname을 멤버 변수로 갖습니다.

## 로그인 절차
SpringSecurity 도입으로 인해 사용자의 요청이 Controller에 도달하기 전에 Filter 계층에서 인증을 수행합니다.

1. 사용자의 요청이 `LoginProcessingFilter`에 도착합니다. attemptAuthentication 메서드가 호출됩니다.
2. `UsernamePasswordAuthenticationProvider`에 인증처리 전의 Authentication이 도착합니다.
실질적인 인증 절차를 수행합니다.
3. 인증이 완료 되면 `LoginProcessingFilter`의 successfulAuthentication 메서드가 호출됩니다.
`SecurityContextHolder`에 인증처리 완료된 `Authentication(MemberAuthenticationToken)`을 등록합니다.
(이 과정 덕분에 컨트롤러 파라미터에서 @AuthenticationPrincipal으로 인증 객체를 받을 수 있게 됩니다.)

## 통합 테스트 결과
웹 계층 테스트 대신 api("/members/info")를 추가했습니다.
시큐리티 필터를 적용한 `@WebMvcTest`는 추후 추가하도록 하겠습니다.

![image](https://github.com/CatDesignProject/CUKZ-BE/assets/54367532/3dc99b00-6d84-453c-b142-5bf08a24667a)
현재는 로그인에 성공할 경우, 세션을 발급해 세션 id를 쿠키로 응답합니다.
JWT를 도입할지, 세션 기반 인증을 그대로 진행할지 논의하고 싶습니다. 

![image](https://github.com/CatDesignProject/CUKZ-BE/assets/54367532/5c319626-98ae-45c8-b7f8-8a4a91a0005e)
`@AuthenticationPrincipal` 애너테이션으로 인증된 회원 객체(`AuthenticatedMember`)를
컨트롤러 파라미터로 주입 받을 수 있습니다.

![image](https://github.com/CatDesignProject/CUKZ-BE/assets/54367532/a2156d98-1375-4426-a744-9e5d9e72f761)
![image](https://github.com/CatDesignProject/CUKZ-BE/assets/54367532/8d0bf8af-7a6d-40e1-b827-ea8740b5f165)
로그인 시 받았던 Cookie를 요청에 담아 전송할 경우
인증에 성공하여 위와 같이 세션 내부에 담긴 회원 정보에 접근해 데이터를 로그로 출력합니다.

![image](https://github.com/CatDesignProject/CUKZ-BE/assets/54367532/fd8b8f88-f6e9-4946-ad3e-2ba76b3051be)
만약 잘못된(만료, 위조 등…) SessionId를 쿠키로 전송할 경우 401 Unauthorized 응답을 받습니다.

## 통합 테스트 시 유의사항
![image](https://github.com/CatDesignProject/CUKZ-BE/assets/54367532/23721e77-87ad-4a01-b0fe-b30a7115dd26)
만약 통합 테스트 시 인증 절차를 무시하려면 anyRequest().permitAll() 으로 고쳐주시면 됩니다.

## PR Checklist
Pull Request가 다음을 만족하는지 확인해주세요.
- [x]  커밋 메시지가 “유형: [#이슈넘버] 메시지” 가이드라인을 준수합니다.
- [ ]  추가, 수정사항에 대한 테스트를 완료했습니다. (feat & bugfix)
