### PR TITLE
feat: [#6] 중복 아이디 검증

### DIFF
--- a/src/main/java/com/example/common/config/s3/S3Config.java
+++ b/src/main/java/com/example/common/config/s3/S3Config.java
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-@Configuration
+//@Configuration
 public class S3Config {
     @Value("${cloud.aws.credentials.access-key}")
     private String accessKey;

--- a/src/main/java/com/example/member/controller/MemberController.java
+++ b/src/main/java/com/example/member/controller/MemberController.java
@@ -23,21 +23,21 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/register")
-    public ResponseEntity registerMember(@RequestBody @Validated MemberRegisterRequestDto memberRegisterRequestDto) {
+    public ResponseEntity<BaseResponse<String>> registerMember(@RequestBody @Validated MemberRegisterRequestDto memberRegisterRequestDto) {
         memberService.registerMember(memberRegisterRequestDto);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(BaseResponse.of(HttpStatus.CREATED, "회원가입 완료"));
     }
 
     @PostMapping("/verify-username")
-    public ResponseEntity registerMember(@RequestBody VerifyUsernameDto verifyUsernameDto) {
+    public ResponseEntity<BaseResponse<String>> registerMember(@RequestBody VerifyUsernameDto verifyUsernameDto) {
         memberService.verifyDuplicatedUsername(verifyUsernameDto.getUsername());
         return ResponseEntity.status(HttpStatus.OK)
                 .body(BaseResponse.of(HttpStatus.OK, "아이디 중복 체크 완료"));
     }
 
     @GetMapping("/info")
-    public ResponseEntity infoMember(@AuthenticationPrincipal AuthenticatedMember authenticatedMember) {
+    public ResponseEntity<BaseResponse<String>> infoMember(@AuthenticationPrincipal AuthenticatedMember authenticatedMember) {
         AuthenticatedMember member = (AuthenticatedMember) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         log.info("member -> {}", member.toString());
         log.info("authenticatedMember -> {}", authenticatedMember.toString());

--- a/src/main/java/com/example/member/controller/MemberController.java
+++ b/src/main/java/com/example/member/controller/MemberController.java
@@ -1,6 +1,8 @@
 package com.example.member.controller;
 
+import com.example.common.global.BaseResponse;
 import com.example.member.dto.MemberRegisterRequestDto;
+import com.example.member.dto.VerifyUsernameDto;
 import com.example.member.service.MemberService;
 import com.example.security.authentication.AuthenticatedMember;
 import lombok.RequiredArgsConstructor;
@@ -23,14 +25,24 @@ public class MemberController {
     @PostMapping("/register")
     public ResponseEntity registerMember(@RequestBody @Validated MemberRegisterRequestDto memberRegisterRequestDto) {
         memberService.registerMember(memberRegisterRequestDto);
-        return new ResponseEntity(HttpStatus.CREATED);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(BaseResponse.of(HttpStatus.CREATED, "회원가입 완료"));
+    }
+
+    @PostMapping("/verify-username")
+    public ResponseEntity registerMember(@RequestBody VerifyUsernameDto verifyUsernameDto) {
+        memberService.verifyDuplicatedUsername(verifyUsernameDto.getUsername());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(BaseResponse.of(HttpStatus.OK, "아이디 중복 체크 완료"));
     }
 
     @GetMapping("/info")
-    public void infoMember(@AuthenticationPrincipal AuthenticatedMember authenticatedMember) {
+    public ResponseEntity infoMember(@AuthenticationPrincipal AuthenticatedMember authenticatedMember) {
         AuthenticatedMember member = (AuthenticatedMember) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         log.info("member -> {}", member.toString());
         log.info("authenticatedMember -> {}", authenticatedMember.toString());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(BaseResponse.of(HttpStatus.OK, authenticatedMember.toString()));
     }
 
 }

--- a/src/main/java/com/example/member/dto/MemberRegisterRequestDto.java
+++ b/src/main/java/com/example/member/dto/MemberRegisterRequestDto.java
@@ -1,5 +1,6 @@
 package com.example.member.dto;
 
+import com.example.member.entity.Member;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
@@ -22,5 +23,13 @@ public class MemberRegisterRequestDto {
         this.username = username;
         this.password = password;
         this.nickname = nickname;
+    }
+
+    public Member toMember() {
+        return Member.builder()
+                .username(this.username)
+                .password(this.password)
+                .nickname(this.nickname)
+                .build();
     }
 }

--- a/src/main/java/com/example/member/dto/VerifyUsernameDto.java
+++ b/src/main/java/com/example/member/dto/VerifyUsernameDto.java
@@ -1,0 +1,15 @@
+package com.example.member.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class VerifyUsernameDto {
+
+    private String username;
+
+    public VerifyUsernameDto(String username) {
+        this.username= username;
+    }
+}

--- a/src/main/java/com/example/member/entity/Member.java
+++ b/src/main/java/com/example/member/entity/Member.java
@@ -1,6 +1,5 @@
 package com.example.member.entity;
 
-import com.example.member.dto.MemberRegisterRequestDto;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -10,6 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -35,13 +35,6 @@ public class Member {
     @Enumerated(EnumType.STRING)
     private MemberRole role;
 
-    public static Member fromMemberRegisterRequestDto(MemberRegisterRequestDto memberRegisterRequestDto) {
-        Member member = new Member();
-        member.username = memberRegisterRequestDto.getUsername();
-        member.nickname = memberRegisterRequestDto.getNickname();
-        return member;
-    }
-
     public void setEncodedPassword(String encodedPassword) {
         this.password = encodedPassword;
     }
@@ -49,5 +42,13 @@ public class Member {
     public void changeNickname(String nickname) {
         this.nickname = nickname;
     }
+
+    @Builder
+    private Member(String username, String password, String nickname) {
+        this.username = username;
+        this.password = password;
+        this.nickname = nickname;
+    }
+
 }
 

--- a/src/main/java/com/example/member/entity/Member.java
+++ b/src/main/java/com/example/member/entity/Member.java
@@ -48,6 +48,7 @@ public class Member {
         this.username = username;
         this.password = password;
         this.nickname = nickname;
+        this.role = MemberRole.user;
     }
 
 }

--- a/src/main/java/com/example/member/service/MemberService.java
+++ b/src/main/java/com/example/member/service/MemberService.java
@@ -1,5 +1,7 @@
 package com.example.member.service;
 
+import com.example.common.exception.BaseErrorCode;
+import com.example.common.exception.GlobalException;
 import com.example.member.dto.MemberRegisterRequestDto;
 import com.example.member.entity.Member;
 import com.example.member.repository.MemberRepository;
@@ -15,9 +17,18 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     public void registerMember(MemberRegisterRequestDto memberRegisterRequestDto) {
-        Member member = Member.fromMemberRegisterRequestDto(memberRegisterRequestDto);
+        String username = memberRegisterRequestDto.getUsername();
+        verifyDuplicatedUsername(username);
+
+        Member member = memberRegisterRequestDto.toMember();
         member.setEncodedPassword(passwordEncoder.encode(memberRegisterRequestDto.getPassword()));
         memberRepository.save(member);
+    }
+
+    public void verifyDuplicatedUsername(String username) {
+        memberRepository.findByUsername(username).ifPresent(member -> {
+            throw new GlobalException(BaseErrorCode.DUPLICATED_MEMBER);
+        });
     }
 
 }

--- a/src/main/java/com/example/product_image/controller/ProductImageController.java
+++ b/src/main/java/com/example/product_image/controller/ProductImageController.java
@@ -13,7 +13,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
-@RestController
+//@RestController
 @RequiredArgsConstructor
 public class ProductImageController {
 

--- a/src/main/java/com/example/product_image/service/ProductImageServiceImpl.java
+++ b/src/main/java/com/example/product_image/service/ProductImageServiceImpl.java
@@ -1,0 +1,106 @@
+package com.example.product_image.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.example.product_image.dto.response.ProductImageResponse;
+import com.example.product_image.entity.ProductImage;
+import com.example.product_image.repository.ProductImageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+//@Service
+@Transactional
+@RequiredArgsConstructor
+public class ProductImageServiceImpl implements ProductImageService {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+    private final AmazonS3Client amazonS3Client;
+    private final ProductImageRepository productImageRepository;
+
+    @Override
+    public List<ProductImageResponse> fileUpload(List<MultipartFile> files) {
+        try {
+            List<ProductImageResponse> productImageResponses = new ArrayList<>();
+
+            for (MultipartFile file : files) {
+                String fileName = createStoreFileName(file.getOriginalFilename());//파일 원본 파일명
+
+                //파일 확장자를 통해 Content-Type 유추
+                String contentType = getContentTypeFromFileName(fileName);
+
+                uploadToS3Server(file, contentType, fileName);
+
+                //이미지 실제 url 얻어옴
+                String imageUrl = getPath(fileName);
+
+                //ProductImage 엔티티 저장
+                ProductImage productImage = productImageRepository.save(
+                        ProductImage.builder()
+                                .uploadFileName(file.getOriginalFilename())
+                                .storeFileName(fileName)
+                                .imageUrl(imageUrl)
+                                .build()
+                );
+
+                productImageResponses.add(new ProductImageResponse(imageUrl, productImage.getId()));
+            }
+
+            //이미지 실제 url과 해당 url의 원래 파일명, 서버에서 관리하는 파일명을 필드로 하는 엔티티의 Id값 반환
+            return productImageResponses;
+
+        } catch (IOException e) {
+            throw new RuntimeException("파일 업로드 실패");
+        }
+    }
+
+    @Override
+    public String getPath(String imagePath) {
+        return amazonS3Client.getUrl(bucket, imagePath).toString();
+    }
+
+    private void uploadToS3Server(MultipartFile file, String contentType, String fileName) throws IOException {
+        ObjectMetadata metadata= new ObjectMetadata();
+        metadata.setContentType(contentType);
+        metadata.setContentLength(file.getSize());
+        amazonS3Client.putObject(bucket, fileName, file.getInputStream(),metadata);
+    }
+
+    private String createStoreFileName(String originalFilename) {
+        String ext = extractExt(originalFilename);
+        String uuid = UUID.randomUUID().toString();
+        return uuid + "." + ext;
+    }
+
+    private String extractExt(String originalFilename) {
+        int pos = originalFilename.lastIndexOf(".");
+        String ext = originalFilename.substring(pos + 1);
+        return ext;
+    }
+
+    private String getContentTypeFromFileName(String fileName) {
+        String extension = fileName.substring(fileName.lastIndexOf('.') + 1);
+
+        // 간단한 매핑 로직을 통해 Content-Type 결정 (필요에 따라 더 확장 가능)
+        switch (extension.toLowerCase()) {
+            case "png":
+                return "image/png";
+            case "jpg":
+            case "jpeg":
+                return "image/jpeg";
+            case "gif":
+                return "image/gif";
+            default:
+                return "application/octet-stream";
+        }
+    }
+
+}

--- a/src/main/java/com/example/security/SecurityConfig.java
+++ b/src/main/java/com/example/security/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
                 .httpBasic(Customizer.withDefaults())
                 .formLogin(login -> login.disable()) // 폼로그인 비허용
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/members/login", "members/register").permitAll() // 로그인, 회원가입 url만 허용
+                        .requestMatchers("/members/login", "/members/register", "/members/verify-username").permitAll()
                         .anyRequest().authenticated())
                 .securityContext(securityContext -> new HttpSessionSecurityContextRepository());
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,19 +13,19 @@ spring:
 
   datasource:
     url: jdbc:mysql://localhost:3306/cukz
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    username: root
+    password: 1234
     driver-class-name: com.mysql.cj.jdbc.Driver
 
-cloud:
-  aws:
-    s3:
-      bucket: ${S3_BUCKET}
-    stack.auto: false
-    region.static: ${S3_REGION}
-    credentials:
-      accessKey: ${S3_ACCESS_KEY}
-      secretKey: ${S3_SECRET_KEY}
+#cloud:
+#  aws:
+#    s3:
+#      bucket: ${S3_BUCKET}
+#    stack.auto: false
+#    region.static: ${S3_region}
+#    credentials:
+#      accessKey: ${S3_ACCESS_KEY}
+#      secretKey: ${S3_SECRET_KEY}
 
 #jwt:
 #  secret_key: ${JWT_SECRET_KEY}


### PR DESCRIPTION
## Issue Number
Resolves #6 


## 변경사항
- MemberController에 BaseResponse 적용
- DTO에 toMember 엔티티 변환 메서드 구현
- 중복 아이디 검증 구현
   - 이미 등록된 아이디일 경우:
   ![image](https://github.com/CatDesignProject/CUKZ-BE/assets/54367532/71849ce7-f2f1-4613-a369-54910c9997ed)

## PR Checklist
Pull Request가 다음을 만족하는지 확인해주세요.
- [x]  커밋 메시지가 “유형: [#이슈넘버] 메시지” 가이드라인을 준수합니다.
- [x]  추가, 수정사항에 대한 테스트를 완료했습니다. (feat & bugfix)
