### PR TITLE
feat: [#3] 수요조사 참여 폼 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/common/exception/BaseErrorCode.java
+++ b/src/main/java/com/example/common/exception/BaseErrorCode.java
@@ -4,20 +4,25 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
 @Getter
 @RequiredArgsConstructor
 public enum BaseErrorCode {
 
     // Member
-    NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "아이디가 일치하지 않습니다."),
-    BAD_CREDENTIAL(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
-    DUPLICATED_MEMBER(HttpStatus.BAD_REQUEST, "이미 등록된 아이디입니다."),
+    NOT_FOUND_MEMBER(NOT_FOUND, "아이디가 일치하지 않습니다."),
+    BAD_CREDENTIAL(BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    DUPLICATED_MEMBER(BAD_REQUEST, "이미 등록된 아이디입니다."),
 
     // Form
-    NOT_FOUND_FORM(HttpStatus.BAD_REQUEST, "해당 폼을 찾을 수 없습니다."),
+    NOT_FOUND_FORM(NOT_FOUND, "해당 폼을 찾을 수 없습니다."),
+    DUPLICATED_FORM(BAD_REQUEST, "이미 참여한 폼이 있습니다."),
+    NOT_IN_PERIOD(BAD_REQUEST, "참여 가능한 기간이 아닙니다."),
 
     // Product
-    NOT_FOUND_PRODUCT(HttpStatus.BAD_REQUEST, "해당 상품을 찾을 수 없습니다.");
+    NOT_FOUND_PRODUCT(NOT_FOUND, "해당 상품을 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String msg;

--- a/src/main/java/com/example/common/exception/BaseErrorCode.java
+++ b/src/main/java/com/example/common/exception/BaseErrorCode.java
@@ -15,6 +15,7 @@ public enum BaseErrorCode {
     NOT_FOUND_MEMBER(NOT_FOUND, "아이디가 일치하지 않습니다."),
     BAD_CREDENTIAL(BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     DUPLICATED_MEMBER(BAD_REQUEST, "이미 등록된 아이디입니다."),
+    MISMATCHED_MEMBER(BAD_REQUEST, "작성자와 일치하지 않는 유저입니다."),
 
     // Form
     NOT_FOUND_FORM(NOT_FOUND, "해당 폼을 찾을 수 없습니다."),

--- a/src/main/java/com/example/common/global/PageResponseDto.java
+++ b/src/main/java/com/example/common/global/PageResponseDto.java
@@ -1,0 +1,30 @@
+package com.example.common.global;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PageResponseDto<T> {
+    private int listSize;
+    private int totalPage;
+    private long totalElements;
+    private boolean isFirst;
+    private boolean isLast;
+    private List<T> content;
+
+    public static <T> PageResponseDto<T> toResponseDto(Page<T> page) {
+
+        return PageResponseDto.<T>builder()
+                .listSize(page.getContent().size())
+                .totalPage(page.getTotalPages())
+                .totalElements(page.getTotalElements())
+                .isFirst(page.isFirst())
+                .isLast(page.isLast())
+                .content(page.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/example/demandForm/controller/DemandFormController.java
+++ b/src/main/java/com/example/demandForm/controller/DemandFormController.java
@@ -1,6 +1,7 @@
 package com.example.demandForm.controller;
 
 import com.example.common.global.BaseResponse;
+import com.example.common.global.PageResponseDto;
 import com.example.demandForm.dto.DemandFormNonMemberRequestDto;
 import com.example.demandForm.dto.DemandFormRequestDto;
 import com.example.demandForm.dto.DemandFormResponseDto;
@@ -42,7 +43,7 @@ public class DemandFormController {
     }
 
     @GetMapping("/members/demand")
-    public ResponseEntity<BaseResponse<Page<DemandFormResponseDto>>> getAllDemandFormsMember(
+    public ResponseEntity<BaseResponse<PageResponseDto<DemandFormResponseDto>>> getAllDemandFormsMember(
             @RequestParam("page") int page,
             @RequestParam("size") int size,
             @AuthenticationPrincipal AuthenticatedMember member) {
@@ -50,7 +51,7 @@ public class DemandFormController {
         Page<DemandFormResponseDto> responseDtoList = demandFormService.getAllDemandFormsMember(page - 1, size,
                 member.getMemberId());
 
-        return ResponseEntity.ok().body(BaseResponse.of(HttpStatus.OK, responseDtoList));
+        return ResponseEntity.ok().body(BaseResponse.of(HttpStatus.OK, PageResponseDto.toResponseDto(responseDtoList)));
     }
 
     @GetMapping("/members/demand/{demandFormId}")

--- a/src/main/java/com/example/demandForm/controller/DemandFormController.java
+++ b/src/main/java/com/example/demandForm/controller/DemandFormController.java
@@ -56,9 +56,10 @@ public class DemandFormController {
 
     @GetMapping("/members/demand/{demandFormId}")
     public ResponseEntity<BaseResponse<DemandFormResponseDto>> getDemandFormMember(
-            @PathVariable Long demandFormId) {
+            @PathVariable Long demandFormId,
+            @AuthenticationPrincipal AuthenticatedMember member) {
 
-        DemandFormResponseDto responseDto = demandFormService.getDemandFormMember(demandFormId);
+        DemandFormResponseDto responseDto = demandFormService.getDemandFormMember(demandFormId, member.getMemberId());
 
         return ResponseEntity.ok().body(BaseResponse.of(HttpStatus.OK, responseDto));
     }

--- a/src/main/java/com/example/demandForm/controller/DemandFormController.java
+++ b/src/main/java/com/example/demandForm/controller/DemandFormController.java
@@ -6,13 +6,11 @@ import com.example.demandForm.service.DemandFormService;
 import com.example.member.entity.Member;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,9 +20,9 @@ public class DemandFormController {
 
     @PostMapping("/products/{productId}/demand/member")
     public ResponseEntity<DemandFormResponseDto> demandMember(
-        @PathVariable Long productId,
-        @Valid @RequestBody DemandFormRequestDto requestDto,
-        @AuthenticationPrincipal Member member) {   // 로그인 구현 후 수정 예정
+            @PathVariable Long productId,
+            @Valid @RequestBody DemandFormRequestDto requestDto,
+            @AuthenticationPrincipal Member member) {   // 로그인 구현 후 수정 예정
 
         DemandFormResponseDto responseDto = demandFormService.demandMember(productId, requestDto, member);
 
@@ -33,11 +31,31 @@ public class DemandFormController {
 
     @PostMapping("/products/{productId}/demand/non-member")
     public ResponseEntity<DemandFormResponseDto> demandNonMember(
-        @PathVariable Long productId,
-        @Valid @RequestBody DemandFormRequestDto requestDto) {
+            @PathVariable Long productId,
+            @Valid @RequestBody DemandFormRequestDto requestDto) {
 
         DemandFormResponseDto responseDto = demandFormService.demandNonMember(productId, requestDto);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+
+    @GetMapping("/members/demand")
+    public ResponseEntity<Page<DemandFormResponseDto>> getAllDemandFormsMember(
+            @RequestParam("page") int page,
+            @RequestParam("size") int size,
+            @AuthenticationPrincipal Member member) {
+
+        Page<DemandFormResponseDto> responseDtoList = demandFormService.getAllDemandFormsMember(page - 1, size, member);
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseDtoList);
+    }
+
+    @GetMapping("/members/demand/{demandFormId}")
+    public ResponseEntity<DemandFormResponseDto> getDemandFormMember(
+            @PathVariable Long demandFormId) {
+
+        DemandFormResponseDto responseDto = demandFormService.getDemandFormMember(demandFormId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
 }

--- a/src/main/java/com/example/demandForm/controller/DemandFormController.java
+++ b/src/main/java/com/example/demandForm/controller/DemandFormController.java
@@ -1,5 +1,6 @@
 package com.example.demandForm.controller;
 
+import com.example.demandForm.dto.DemandFormNonMemberRequestDto;
 import com.example.demandForm.dto.DemandFormRequestDto;
 import com.example.demandForm.dto.DemandFormResponseDto;
 import com.example.demandForm.service.DemandFormService;
@@ -55,6 +56,15 @@ public class DemandFormController {
             @PathVariable Long demandFormId) {
 
         DemandFormResponseDto responseDto = demandFormService.getDemandFormMember(demandFormId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+    }
+
+    @GetMapping("/demand/non-member")
+    public ResponseEntity<DemandFormResponseDto> getDemandFormNonMember(
+            @RequestBody DemandFormNonMemberRequestDto requestDto) {
+
+        DemandFormResponseDto responseDto = demandFormService.getDemandFormNonMember(requestDto);
 
         return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }

--- a/src/main/java/com/example/demandForm/controller/DemandFormController.java
+++ b/src/main/java/com/example/demandForm/controller/DemandFormController.java
@@ -1,5 +1,6 @@
 package com.example.demandForm.controller;
 
+import com.example.common.global.BaseResponse;
 import com.example.demandForm.dto.DemandFormNonMemberRequestDto;
 import com.example.demandForm.dto.DemandFormRequestDto;
 import com.example.demandForm.dto.DemandFormResponseDto;
@@ -20,28 +21,28 @@ public class DemandFormController {
     private final DemandFormService demandFormService;
 
     @PostMapping("/products/{productId}/demand/member")
-    public ResponseEntity<DemandFormResponseDto> demandMember(
+    public ResponseEntity<BaseResponse<DemandFormResponseDto>> demandMember(
             @PathVariable Long productId,
             @Valid @RequestBody DemandFormRequestDto requestDto,
             @AuthenticationPrincipal AuthenticatedMember member) {
 
         DemandFormResponseDto responseDto = demandFormService.demandMember(productId, requestDto, member.getMemberId());
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+        return ResponseEntity.ok().body(BaseResponse.of(HttpStatus.CREATED, responseDto));
     }
 
     @PostMapping("/products/{productId}/demand/non-member")
-    public ResponseEntity<DemandFormResponseDto> demandNonMember(
+    public ResponseEntity<BaseResponse<DemandFormResponseDto>> demandNonMember(
             @PathVariable Long productId,
             @Valid @RequestBody DemandFormRequestDto requestDto) {
 
         DemandFormResponseDto responseDto = demandFormService.demandNonMember(productId, requestDto);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+        return ResponseEntity.ok().body(BaseResponse.of(HttpStatus.CREATED, responseDto));
     }
 
     @GetMapping("/members/demand")
-    public ResponseEntity<Page<DemandFormResponseDto>> getAllDemandFormsMember(
+    public ResponseEntity<BaseResponse<Page<DemandFormResponseDto>>> getAllDemandFormsMember(
             @RequestParam("page") int page,
             @RequestParam("size") int size,
             @AuthenticationPrincipal AuthenticatedMember member) {
@@ -49,24 +50,24 @@ public class DemandFormController {
         Page<DemandFormResponseDto> responseDtoList = demandFormService.getAllDemandFormsMember(page - 1, size,
                 member.getMemberId());
 
-        return ResponseEntity.status(HttpStatus.OK).body(responseDtoList);
+        return ResponseEntity.ok().body(BaseResponse.of(HttpStatus.OK, responseDtoList));
     }
 
     @GetMapping("/members/demand/{demandFormId}")
-    public ResponseEntity<DemandFormResponseDto> getDemandFormMember(
+    public ResponseEntity<BaseResponse<DemandFormResponseDto>> getDemandFormMember(
             @PathVariable Long demandFormId) {
 
         DemandFormResponseDto responseDto = demandFormService.getDemandFormMember(demandFormId);
 
-        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+        return ResponseEntity.ok().body(BaseResponse.of(HttpStatus.OK, responseDto));
     }
 
     @GetMapping("/demand/non-member")
-    public ResponseEntity<DemandFormResponseDto> getDemandFormNonMember(
+    public ResponseEntity<BaseResponse<DemandFormResponseDto>> getDemandFormNonMember(
             @RequestBody DemandFormNonMemberRequestDto requestDto) {
 
         DemandFormResponseDto responseDto = demandFormService.getDemandFormNonMember(requestDto);
 
-        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+        return ResponseEntity.ok().body(BaseResponse.of(HttpStatus.OK, responseDto));
     }
 }

--- a/src/main/java/com/example/demandForm/controller/DemandFormController.java
+++ b/src/main/java/com/example/demandForm/controller/DemandFormController.java
@@ -4,7 +4,7 @@ import com.example.demandForm.dto.DemandFormNonMemberRequestDto;
 import com.example.demandForm.dto.DemandFormRequestDto;
 import com.example.demandForm.dto.DemandFormResponseDto;
 import com.example.demandForm.service.DemandFormService;
-import com.example.member.entity.Member;
+import com.example.security.authentication.AuthenticatedMember;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -23,9 +23,9 @@ public class DemandFormController {
     public ResponseEntity<DemandFormResponseDto> demandMember(
             @PathVariable Long productId,
             @Valid @RequestBody DemandFormRequestDto requestDto,
-            @AuthenticationPrincipal Member member) {   // 로그인 구현 후 수정 예정
+            @AuthenticationPrincipal AuthenticatedMember member) {
 
-        DemandFormResponseDto responseDto = demandFormService.demandMember(productId, requestDto, member);
+        DemandFormResponseDto responseDto = demandFormService.demandMember(productId, requestDto, member.getMemberId());
 
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
@@ -44,9 +44,10 @@ public class DemandFormController {
     public ResponseEntity<Page<DemandFormResponseDto>> getAllDemandFormsMember(
             @RequestParam("page") int page,
             @RequestParam("size") int size,
-            @AuthenticationPrincipal Member member) {
+            @AuthenticationPrincipal AuthenticatedMember member) {
 
-        Page<DemandFormResponseDto> responseDtoList = demandFormService.getAllDemandFormsMember(page - 1, size, member);
+        Page<DemandFormResponseDto> responseDtoList = demandFormService.getAllDemandFormsMember(page - 1, size,
+                member.getMemberId());
 
         return ResponseEntity.status(HttpStatus.OK).body(responseDtoList);
     }

--- a/src/main/java/com/example/demandForm/dto/DemandFormNonMemberRequestDto.java
+++ b/src/main/java/com/example/demandForm/dto/DemandFormNonMemberRequestDto.java
@@ -1,0 +1,11 @@
+package com.example.demandForm.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DemandFormNonMemberRequestDto {
+
+    private Long orderNumber;
+}

--- a/src/main/java/com/example/demandForm/dto/DemandFormRequestDto.java
+++ b/src/main/java/com/example/demandForm/dto/DemandFormRequestDto.java
@@ -1,5 +1,6 @@
 package com.example.demandForm.dto;
 
+import jakarta.validation.constraints.Min;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -7,5 +8,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class DemandFormRequestDto {
 
+    @Min(value = 1, message = "수량은 1개 이상 입력해주세요")
     private int quantity;
 }

--- a/src/main/java/com/example/demandForm/repository/DemandFormRepository.java
+++ b/src/main/java/com/example/demandForm/repository/DemandFormRepository.java
@@ -1,10 +1,15 @@
 package com.example.demandForm.repository;
 
 import com.example.demandForm.entity.DemandForm;
-import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 public interface DemandFormRepository extends JpaRepository<DemandForm, Long> {
 
     Optional<DemandForm> findByProductIdAndMemberId(Long productId, Long memberId);
+
+    Page<DemandForm> findByMemberId(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/example/demandForm/repository/DemandFormRepository.java
+++ b/src/main/java/com/example/demandForm/repository/DemandFormRepository.java
@@ -13,6 +13,8 @@ public interface DemandFormRepository extends JpaRepository<DemandForm, Long> {
 
     Optional<DemandForm> findByProductIdAndMemberId(Long productId, Long memberId);
 
+    Optional<DemandForm> findByIdAndMemberId(Long demandFormId, Long memberId);
+
     Page<DemandForm> findByMemberId(Long memberId, Pageable pageable);
 
     @Query("SELECT df FROM DemandForm df WHERE df.memberId = :orderNumber")

--- a/src/main/java/com/example/demandForm/repository/DemandFormRepository.java
+++ b/src/main/java/com/example/demandForm/repository/DemandFormRepository.java
@@ -4,6 +4,8 @@ import com.example.demandForm.entity.DemandForm;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -12,4 +14,7 @@ public interface DemandFormRepository extends JpaRepository<DemandForm, Long> {
     Optional<DemandForm> findByProductIdAndMemberId(Long productId, Long memberId);
 
     Page<DemandForm> findByMemberId(Long memberId, Pageable pageable);
+
+    @Query("SELECT df FROM DemandForm df WHERE df.memberId = :orderNumber")
+    Optional<DemandForm> findByOrderNumber(@Param("orderNumber") Long orderNumber);
 }

--- a/src/main/java/com/example/demandForm/service/DemandFormService.java
+++ b/src/main/java/com/example/demandForm/service/DemandFormService.java
@@ -77,7 +77,6 @@ public class DemandFormService {
     @Transactional(readOnly = true)
     public Page<DemandFormResponseDto> getAllDemandFormsMember(int page, int size, Long memberId) {
 
-        Member member = findMember(memberId);
         Sort sort = Sort.by(Sort.Direction.DESC, "id");
         Pageable pageable = PageRequest.of(page, size, sort);
         Page<DemandForm> demandFormList = demandFormRepository.findByMemberId(memberId, pageable);

--- a/src/main/java/com/example/demandForm/service/DemandFormService.java
+++ b/src/main/java/com/example/demandForm/service/DemandFormService.java
@@ -66,11 +66,12 @@ public class DemandFormService {
     }
 
     @Transactional(readOnly = true)
-    public DemandFormResponseDto getDemandFormMember(Long demandFormId) {
+    public DemandFormResponseDto getDemandFormMember(Long demandFormId, Long memberId) {
 
         DemandForm demandForm = demandFormRepository.findById(demandFormId).orElseThrow(() ->
                 new GlobalException(NOT_FOUND_FORM)
         );
+        checkMember(demandFormId, memberId);
 
         return DemandFormResponseDto.toResponseDto(demandForm);
     }
@@ -119,6 +120,12 @@ public class DemandFormService {
         return productRepository.findById(productId).orElseThrow(() ->
                 new GlobalException(NOT_FOUND_PRODUCT)
         );
+    }
+
+    private void checkMember(Long demandFormId, Long memberId) {
+        if (!demandFormId.equals(memberId)) {
+            throw new GlobalException(MISMATCHED_MEMBER);
+        }
     }
 
     public void checkPeriod(Product product) {

--- a/src/main/java/com/example/demandForm/service/DemandFormService.java
+++ b/src/main/java/com/example/demandForm/service/DemandFormService.java
@@ -7,13 +7,18 @@ import com.example.demandForm.repository.DemandFormRepository;
 import com.example.member.entity.Member;
 import com.example.product.entity.Product;
 import com.example.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.Random;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -28,8 +33,7 @@ public class DemandFormService {
 
         // to-do : member role 검증
 
-        Optional<DemandForm> demandFormExist = demandFormRepository.findByProductIdAndMemberId(
-            productId, member.getId());
+        Optional<DemandForm> demandFormExist = demandFormRepository.findByProductIdAndMemberId(productId, member.getId());
         if (demandFormExist.isPresent()) {
             throw new IllegalArgumentException("이미 수요조사에 참여하였습니다.");
         }
@@ -56,6 +60,26 @@ public class DemandFormService {
         return DemandFormResponseDto.toResponseDto(demandForm);
     }
 
+    @Transactional(readOnly = true)
+    public DemandFormResponseDto getDemandFormMember(Long demandFormId) {
+
+        DemandForm demandForm = demandFormRepository.findById(demandFormId).orElseThrow(() ->
+                new IllegalArgumentException("폼을 찾을 수 없습니다.")
+        );
+
+        return DemandFormResponseDto.toResponseDto(demandForm);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<DemandFormResponseDto> getAllDemandFormsMember(int page, int size, Member member) {
+
+        Sort sort = Sort.by(Sort.Direction.DESC, "id");
+        Pageable pageable = PageRequest.of(page, size, sort);
+        Page<DemandForm> demandFormList = demandFormRepository.findByMemberId(member.getId(), pageable);
+
+        return demandFormList.map(DemandFormResponseDto::toResponseDto);
+    }
+
     public long generateOrderNumber() {
         // 비회원 주문 번호 = 현재 날짜 + 랜덤 숫자 (16자리)
         LocalDate today = LocalDate.now();
@@ -75,9 +99,9 @@ public class DemandFormService {
         );
     }
 
-    public void checkPeriod(Product product){
+    public void checkPeriod(Product product) {
         LocalDateTime now = LocalDateTime.now();
-        if(now.isAfter(product.getEndDate()) || now.isBefore(product.getStartDate())) {
+        if (now.isAfter(product.getEndDate()) || now.isBefore(product.getStartDate())) {
             throw new IllegalArgumentException("수요조사 참여 가능 기간이 아닙니다.");
         }
     }

--- a/src/main/java/com/example/demandForm/service/DemandFormService.java
+++ b/src/main/java/com/example/demandForm/service/DemandFormService.java
@@ -68,10 +68,8 @@ public class DemandFormService {
     @Transactional(readOnly = true)
     public DemandFormResponseDto getDemandFormMember(Long demandFormId, Long memberId) {
 
-        DemandForm demandForm = demandFormRepository.findById(demandFormId).orElseThrow(() ->
-                new GlobalException(NOT_FOUND_FORM)
-        );
-        checkMember(demandFormId, memberId);
+        DemandForm demandForm = demandFormRepository.findByIdAndMemberId(demandFormId, memberId)
+                .orElseThrow(() -> new GlobalException(NOT_FOUND_FORM));
 
         return DemandFormResponseDto.toResponseDto(demandForm);
     }
@@ -120,12 +118,6 @@ public class DemandFormService {
         return productRepository.findById(productId).orElseThrow(() ->
                 new GlobalException(NOT_FOUND_PRODUCT)
         );
-    }
-
-    private void checkMember(Long demandFormId, Long memberId) {
-        if (!demandFormId.equals(memberId)) {
-            throw new GlobalException(MISMATCHED_MEMBER);
-        }
     }
 
     public void checkPeriod(Product product) {

--- a/src/main/java/com/example/demandForm/service/DemandFormService.java
+++ b/src/main/java/com/example/demandForm/service/DemandFormService.java
@@ -1,5 +1,6 @@
 package com.example.demandForm.service;
 
+import com.example.demandForm.dto.DemandFormNonMemberRequestDto;
 import com.example.demandForm.dto.DemandFormRequestDto;
 import com.example.demandForm.dto.DemandFormResponseDto;
 import com.example.demandForm.entity.DemandForm;
@@ -78,6 +79,16 @@ public class DemandFormService {
         Page<DemandForm> demandFormList = demandFormRepository.findByMemberId(member.getId(), pageable);
 
         return demandFormList.map(DemandFormResponseDto::toResponseDto);
+    }
+
+    @Transactional(readOnly = true)
+    public DemandFormResponseDto getDemandFormNonMember(DemandFormNonMemberRequestDto requestDto) {
+
+        DemandForm demandForm = demandFormRepository.findByOrderNumber(requestDto.getOrderNumber()).orElseThrow(() ->
+                new IllegalArgumentException("폼을 찾을 수 없습니다.")
+        );
+
+        return DemandFormResponseDto.toResponseDto(demandForm);
     }
 
     public long generateOrderNumber() {

--- a/src/main/java/com/example/demandForm/service/DemandFormService.java
+++ b/src/main/java/com/example/demandForm/service/DemandFormService.java
@@ -1,11 +1,13 @@
 package com.example.demandForm.service;
 
+import com.example.common.exception.GlobalException;
 import com.example.demandForm.dto.DemandFormNonMemberRequestDto;
 import com.example.demandForm.dto.DemandFormRequestDto;
 import com.example.demandForm.dto.DemandFormResponseDto;
 import com.example.demandForm.entity.DemandForm;
 import com.example.demandForm.repository.DemandFormRepository;
 import com.example.member.entity.Member;
+import com.example.member.repository.MemberRepository;
 import com.example.product.entity.Product;
 import com.example.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,22 +23,24 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.Random;
 
+import static com.example.common.exception.BaseErrorCode.*;
+
 @Service
 @RequiredArgsConstructor
 public class DemandFormService {
 
     private final DemandFormRepository demandFormRepository;
     private final ProductRepository productRepository;
+    private final MemberRepository memberRepository;
     private static final long MAX_ORDER_NUMBER = 9999999999L;
 
     @Transactional
-    public DemandFormResponseDto demandMember(Long productId, DemandFormRequestDto requestDto, Member member) {
+    public DemandFormResponseDto demandMember(Long productId, DemandFormRequestDto requestDto, Long memberId) {
 
-        // to-do : member role 검증
-
+        Member member = findMember(memberId);
         Optional<DemandForm> demandFormExist = demandFormRepository.findByProductIdAndMemberId(productId, member.getId());
         if (demandFormExist.isPresent()) {
-            throw new IllegalArgumentException("이미 수요조사에 참여하였습니다.");
+            throw new GlobalException(DUPLICATED_FORM);
         }
 
         Product product = findProduct(productId);
@@ -65,18 +69,19 @@ public class DemandFormService {
     public DemandFormResponseDto getDemandFormMember(Long demandFormId) {
 
         DemandForm demandForm = demandFormRepository.findById(demandFormId).orElseThrow(() ->
-                new IllegalArgumentException("폼을 찾을 수 없습니다.")
+                new GlobalException(NOT_FOUND_FORM)
         );
 
         return DemandFormResponseDto.toResponseDto(demandForm);
     }
 
     @Transactional(readOnly = true)
-    public Page<DemandFormResponseDto> getAllDemandFormsMember(int page, int size, Member member) {
+    public Page<DemandFormResponseDto> getAllDemandFormsMember(int page, int size, Long memberId) {
 
+        Member member = findMember(memberId);
         Sort sort = Sort.by(Sort.Direction.DESC, "id");
         Pageable pageable = PageRequest.of(page, size, sort);
-        Page<DemandForm> demandFormList = demandFormRepository.findByMemberId(member.getId(), pageable);
+        Page<DemandForm> demandFormList = demandFormRepository.findByMemberId(memberId, pageable);
 
         return demandFormList.map(DemandFormResponseDto::toResponseDto);
     }
@@ -85,7 +90,7 @@ public class DemandFormService {
     public DemandFormResponseDto getDemandFormNonMember(DemandFormNonMemberRequestDto requestDto) {
 
         DemandForm demandForm = demandFormRepository.findByOrderNumber(requestDto.getOrderNumber()).orElseThrow(() ->
-                new IllegalArgumentException("폼을 찾을 수 없습니다.")
+                new GlobalException(NOT_FOUND_FORM)
         );
 
         return DemandFormResponseDto.toResponseDto(demandForm);
@@ -104,16 +109,22 @@ public class DemandFormService {
         return Long.parseLong(orderNumberStr);
     }
 
+    private Member findMember(Long memberId) {
+        return memberRepository.findById(memberId).orElseThrow(() ->
+                new GlobalException(NOT_FOUND_MEMBER)
+        );
+    }
+
     private Product findProduct(Long productId) {
         return productRepository.findById(productId).orElseThrow(() ->
-                new IllegalArgumentException("상품을 찾을 수 없습니다.")
+                new GlobalException(NOT_FOUND_PRODUCT)
         );
     }
 
     public void checkPeriod(Product product) {
         LocalDateTime now = LocalDateTime.now();
         if (now.isAfter(product.getEndDate()) || now.isBefore(product.getStartDate())) {
-            throw new IllegalArgumentException("수요조사 참여 가능 기간이 아닙니다.");
+            throw new GlobalException(NOT_IN_PERIOD);
         }
     }
 }

--- a/src/test/java/com/example/demandForm/service/DemandFormServiceTest.java
+++ b/src/test/java/com/example/demandForm/service/DemandFormServiceTest.java
@@ -173,7 +173,7 @@ public class DemandFormServiceTest {
         @DisplayName("성공(일반 유저)")
         void getMemberDemandFormTest_success() {
             //given
-            when(demandFormRepository.findById(formId)).thenReturn(Optional.of(memberDemandForm));
+            when(demandFormRepository.findByIdAndMemberId(formId, memberId)).thenReturn(Optional.of(memberDemandForm));
 
             //when
             DemandFormResponseDto responseDto = demandFormService.getDemandFormMember(formId, memberId);
@@ -188,13 +188,13 @@ public class DemandFormServiceTest {
         @DisplayName("실패(일반 유저) - 작성자와 불일치")
         void getMemberDemandFormTest_fail_misMatched() {
             //given
-            when(demandFormRepository.findById(formId)).thenReturn(Optional.of(memberDemandForm));
+            when(demandFormRepository.findByIdAndMemberId(formId, 2L)).thenReturn(Optional.empty());
 
             //when - then
             GlobalException e = assertThrows(GlobalException.class, () -> {
                 demandFormService.getDemandFormMember(formId, 2L);
             });
-            assertEquals(MISMATCHED_MEMBER, e.getErrorCode());
+            assertEquals(NOT_FOUND_FORM, e.getErrorCode());
         }
 
         @Test

--- a/src/test/java/com/example/demandForm/service/DemandFormServiceTest.java
+++ b/src/test/java/com/example/demandForm/service/DemandFormServiceTest.java
@@ -132,7 +132,7 @@ public class DemandFormServiceTest {
         }
 
         @Test
-        @DisplayName("실패(일반 유저) - 참여 가능한 기간이 아님")
+        @DisplayName("실패(일반 유저) - 참여 기간이 아님")
         void demandMemberTest_fail_isNotPeriod() {
             // given
             when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
@@ -176,12 +176,25 @@ public class DemandFormServiceTest {
             when(demandFormRepository.findById(formId)).thenReturn(Optional.of(memberDemandForm));
 
             //when
-            DemandFormResponseDto responseDto = demandFormService.getDemandFormMember(formId);
+            DemandFormResponseDto responseDto = demandFormService.getDemandFormMember(formId, memberId);
 
             //then
             assertEquals(quantity, responseDto.getQuantity());
             assertEquals(productId, responseDto.getProductId());
             assertEquals(memberId, responseDto.getMemberId());
+        }
+
+        @Test
+        @DisplayName("실패(일반 유저) - 작성자와 불일치")
+        void getMemberDemandFormTest_fail_misMatched() {
+            //given
+            when(demandFormRepository.findById(formId)).thenReturn(Optional.of(memberDemandForm));
+
+            //when - then
+            GlobalException e = assertThrows(GlobalException.class, () -> {
+                demandFormService.getDemandFormMember(formId, 2L);
+            });
+            assertEquals(MISMATCHED_MEMBER, e.getErrorCode());
         }
 
         @Test


### PR DESCRIPTION
## Issue Number
Resolves #3 

## 변경사항
- 수요조사 폼 단건 조회 API - 유저
- 수요조사 폼 목록 조회 API - 유저
- 수요조사 폼 단건 조회 API - 비회원
- BaseResponse, GlobalException 적용
- PageResponseDto 생성
- @AuthenticationPrincipal 적용


## PR Checklist
Pull Request가 다음을 만족하는지 확인해주세요.
- [x]  커밋 메시지가 “유형: [#이슈넘버] 메시지” 가이드라인을 준수합니다.
- [x]  추가, 수정사항에 대한 테스트를 완료했습니다. (feat & bugfix)
