### PR TITLE
feat: [#19] 시큐리티 필터 체인 인증, 인가 예외처리

### DIFF
--- a/src/main/java/com/example/common/exception/BaseErrorCode.java
+++ b/src/main/java/com/example/common/exception/BaseErrorCode.java
@@ -4,9 +4,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
-import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.*;
 
 @Getter
 @RequiredArgsConstructor
@@ -17,6 +15,7 @@ public enum BaseErrorCode {
     BAD_CREDENTIAL(BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     DUPLICATED_MEMBER(BAD_REQUEST, "이미 등록된 아이디입니다."),
     MISMATCHED_MEMBER(BAD_REQUEST, "작성자와 일치하지 않는 유저입니다."),
+    UNAUTHORIZED_MEMBER(FORBIDDEN, "권한이 없습니다."),
 
     // Form
     NOT_FOUND_FORM(NOT_FOUND, "해당 폼을 찾을 수 없습니다."),
@@ -28,7 +27,10 @@ public enum BaseErrorCode {
     UNAUTHORIZED_MODIFY_PRODUCT(FORBIDDEN, "해당 상품을 수정할 권한이 없습니다."),
 
     //Image
-    NOT_FOUND_IMAGE(BAD_REQUEST, "해당 이미지를 찾을 수 없습니다.");
+    NOT_FOUND_IMAGE(BAD_REQUEST, "해당 이미지를 찾을 수 없습니다."),
+
+    // Security
+    BASE_SECURITY_EXCEPTION(UNAUTHORIZED, "인증되지 않은 사용자입니다.");
 
     private final HttpStatus status;
     private final String msg;

--- a/src/main/java/com/example/common/exception/BaseErrorCode.java
+++ b/src/main/java/com/example/common/exception/BaseErrorCode.java
@@ -30,7 +30,8 @@ public enum BaseErrorCode {
     NOT_FOUND_IMAGE(BAD_REQUEST, "해당 이미지를 찾을 수 없습니다."),
 
     // Security
-    BASE_SECURITY_EXCEPTION(UNAUTHORIZED, "인증되지 않은 사용자입니다.");
+    BASE_SECURITY_EXCEPTION(UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+    FORBIDDEN_REQUEST(FORBIDDEN, "접근 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String msg;

--- a/src/main/java/com/example/security/SecurityConfig.java
+++ b/src/main/java/com/example/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.example.security;
 
 import com.example.security.authentication.LoginProcessingFilter;
+import com.example.security.exception.CustomAccessDeniedHandler;
 import com.example.security.exception.CustomAuthenticationEntryPoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -35,6 +36,7 @@ public class SecurityConfig {
                 .exceptionHandling(exceptionHandling -> exceptionHandling
                         .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
                 );
+                        .accessDeniedHandler(new CustomAccessDeniedHandler()));
 
         return http.build();
     }

--- a/src/main/java/com/example/security/SecurityConfig.java
+++ b/src/main/java/com/example/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.example.security;
 
 import com.example.security.authentication.LoginProcessingFilter;
+import com.example.security.exception.CustomAuthenticationEntryPoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -30,7 +31,10 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/members/login", "/members/register", "/members/verify-username").permitAll()
                         .anyRequest().authenticated())
-                .securityContext(securityContext -> new HttpSessionSecurityContextRepository());
+                .securityContext(securityContext -> new HttpSessionSecurityContextRepository())
+                .exceptionHandling(exceptionHandling -> exceptionHandling
+                        .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
+                );
 
         return http.build();
     }

--- a/src/main/java/com/example/security/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/security/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,33 @@
+package com.example.security.exception;
+
+import com.example.common.exception.BaseErrorCode;
+import com.example.common.exception.ExceptionResponseDto;
+import com.example.common.global.BaseResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        BaseErrorCode errorCode = BaseErrorCode.FORBIDDEN_REQUEST;
+
+        ExceptionResponseDto exceptionResponseDto = new ExceptionResponseDto(errorCode);
+        BaseResponse<ExceptionResponseDto> responseDto = BaseResponse.of(HttpStatus.FORBIDDEN, exceptionResponseDto);
+
+        String responseJson = objectMapper.writeValueAsString(responseDto);
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write(responseJson);
+    }
+}

--- a/src/main/java/com/example/security/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/security/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,35 @@
+package com.example.security.exception;
+
+import com.example.common.exception.BaseErrorCode;
+import com.example.common.exception.ExceptionResponseDto;
+import com.example.common.global.BaseResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        // 1. 발생한 AuthenticationException에 대해 BaseErrorCode를 생성한다.
+        BaseErrorCode errorCode = BaseErrorCode.BASE_SECURITY_EXCEPTION;
+
+        // 2. BaseResponse 객체에 ExceptionResponseDTO를 담는다.
+        ExceptionResponseDto exceptionResponseDto = new ExceptionResponseDto(errorCode);
+        BaseResponse<ExceptionResponseDto> responseDto = BaseResponse.of(errorCode.getStatus(), exceptionResponseDto);
+
+        // 3. ObjectMapper로 BaseResponse를 json으로 변환해 response에서 writer를 얻어 write한다.
+        String responseJson = objectMapper.writeValueAsString(responseDto);
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write(responseJson);
+    }
+}


### PR DESCRIPTION
## Issue Number
Related to #19 


## 변경사항
- 시큐리티 필터 체인 스코프 내 발생하는 인증, 인가 예외처리 구현
   - 인증 예외: CustomAuthenticationEntryPoint
   - 인가 예외: CustomAccessDeniedHandler

- 컨트롤러 스코프 응답 BaseResponse를 적용했습니다.
   ![image](https://github.com/CatDesignProject/CUKZ-BE/assets/54367532/50b504f8-539f-4d58-a1a4-ae27ba1102b4)


## PR Checklist
Pull Request가 다음을 만족하는지 확인해주세요.
- [x]  커밋 메시지가 “유형: [#이슈넘버] 메시지” 가이드라인을 준수합니다.
- [x]  추가, 수정사항에 대한 테스트를 완료했습니다. (feat & bugfix)
