### PR TITLE
feat: [#9] 로그인 성공, 실패 응답 핸들러 구현, 인증 객체 role 필드 추가

### DIFF
--- a/src/main/java/com/example/security/SecurityConfig.java
+++ b/src/main/java/com/example/security/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.example.security;
 
+import com.example.security.authentication.CustomAuthenticationFailureHandler;
+import com.example.security.authentication.CustomAuthenticationSuccessHandler;
 import com.example.security.authentication.LoginProcessingFilter;
 import com.example.security.exception.CustomAccessDeniedHandler;
 import com.example.security.exception.CustomAuthenticationEntryPoint;
@@ -35,7 +37,6 @@ public class SecurityConfig {
                 .securityContext(securityContext -> new HttpSessionSecurityContextRepository())
                 .exceptionHandling(exceptionHandling -> exceptionHandling
                         .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
-                );
                         .accessDeniedHandler(new CustomAccessDeniedHandler()));
 
         return http.build();
@@ -55,6 +56,8 @@ public class SecurityConfig {
     public LoginProcessingFilter loginProcessingFilter(AuthenticationManager authenticationManager) {
         LoginProcessingFilter loginProcessingFilter = new LoginProcessingFilter();
         loginProcessingFilter.setAuthenticationManager(authenticationManager);
+        loginProcessingFilter.setAuthenticationSuccessHandler(new CustomAuthenticationSuccessHandler());
+        loginProcessingFilter.setAuthenticationFailureHandler(new CustomAuthenticationFailureHandler());
         return loginProcessingFilter;
     }
 

--- a/src/main/java/com/example/security/authentication/AuthenticatedMember.java
+++ b/src/main/java/com/example/security/authentication/AuthenticatedMember.java
@@ -1,5 +1,6 @@
 package com.example.security.authentication;
 
+import com.example.member.entity.MemberRole;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -14,23 +15,27 @@ public class AuthenticatedMember {
 
     private Long memberId;
     private String nickName;
+    private MemberRole role;
 
     @Override
     public boolean equals(Object obj) {
         if (this == obj) return true;
-        if (this.hashCode() != obj.hashCode()) return false;
-        return true;
+        if(obj == null || getClass() != obj.getClass()) return false;
+        AuthenticatedMember authenticatedMember = (AuthenticatedMember) obj;
+        return Objects.equals(this.memberId, authenticatedMember.memberId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(memberId, nickName);
+        return Objects.hash(memberId);
     }
 
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("memberId: ").append(memberId).append(", nickname: ").append(nickName);
+        sb.append("memberId: ").append(memberId)
+                .append(", nickname: ").append(nickName)
+                .append(", role: ").append(role.name());
         return sb.toString();
     }
 }

--- a/src/main/java/com/example/security/authentication/CustomAuthenticationFailureHandler.java
+++ b/src/main/java/com/example/security/authentication/CustomAuthenticationFailureHandler.java
@@ -1,0 +1,29 @@
+package com.example.security.authentication;
+
+import com.example.common.global.BaseResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+import java.io.IOException;
+
+public class CustomAuthenticationFailureHandler implements AuthenticationFailureHandler {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        BaseResponse<Boolean> loginFailureResponseDto = BaseResponse.of(HttpStatus.OK, false);
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        response.getWriter().write(objectMapper.writeValueAsString(loginFailureResponseDto));
+        response.flushBuffer();
+    }
+}

--- a/src/main/java/com/example/security/authentication/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/security/authentication/CustomAuthenticationSuccessHandler.java
@@ -1,0 +1,31 @@
+package com.example.security.authentication;
+
+import com.example.common.global.BaseResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+import java.io.IOException;
+
+@Slf4j
+public class CustomAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        BaseResponse<Boolean> loginSuccessResponseDto = BaseResponse.of(HttpStatus.OK, true);
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        response.getWriter().write(objectMapper.writeValueAsString(loginSuccessResponseDto));
+        response.flushBuffer();
+    }
+}

--- a/src/main/java/com/example/security/authentication/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/security/authentication/CustomAuthenticationSuccessHandler.java
@@ -20,12 +20,22 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
-        BaseResponse<Boolean> loginSuccessResponseDto = BaseResponse.of(HttpStatus.OK, true);
 
+        // 1. 인증된 AuthenticatedMember 객체를 꺼낸다.
+        AuthenticatedMember authenticatedMember = (AuthenticatedMember) authentication.getPrincipal();
+
+        LoginSuccessResponseDto loginSuccessResponseDto = LoginSuccessResponseDto.builder()
+                .memberId(authenticatedMember.getMemberId())
+                .nickname(authenticatedMember.getNickName())
+                .role(authenticatedMember.getRole().name())
+                .build();
+
+        BaseResponse<LoginSuccessResponseDto> responseDto = BaseResponse.of(HttpStatus.OK, loginSuccessResponseDto);
+
+        // 2. 응답한다.
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
-
-        response.getWriter().write(objectMapper.writeValueAsString(loginSuccessResponseDto));
+        response.getWriter().write(objectMapper.writeValueAsString(responseDto));
         response.flushBuffer();
     }
 }

--- a/src/main/java/com/example/security/authentication/LoginSuccessResponseDto.java
+++ b/src/main/java/com/example/security/authentication/LoginSuccessResponseDto.java
@@ -1,0 +1,14 @@
+package com.example.security.authentication;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class LoginSuccessResponseDto {
+    private Long memberId;
+    private String nickname;
+    private String role;
+}

--- a/src/main/java/com/example/security/authentication/UsernamePasswordAuthenticationProvider.java
+++ b/src/main/java/com/example/security/authentication/UsernamePasswordAuthenticationProvider.java
@@ -36,7 +36,7 @@ public class UsernamePasswordAuthenticationProvider implements AuthenticationPro
         }
 
         // 3. 인증 성공 시 Authentication 토큰 생성
-        AuthenticatedMember authenticatedMember = new AuthenticatedMember(findMember.getId(), findMember.getNickname());
+        AuthenticatedMember authenticatedMember = new AuthenticatedMember(findMember.getId(), findMember.getNickname(), findMember.getRole());
         return MemberAuthenticationToken.authenticated(authenticatedMember);
     }
 

--- a/src/test/java/com/example/security/authentication/AuthenticatedMemberTest.java
+++ b/src/test/java/com/example/security/authentication/AuthenticatedMemberTest.java
@@ -1,5 +1,6 @@
 package com.example.security.authentication;
 
+import com.example.member.entity.MemberRole;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,8 +11,8 @@ class AuthenticatedMemberTest {
     @DisplayName("AuthenticatedMember equals 테스트")
     void equalsTest() {
         // given
-        AuthenticatedMember member1 = new AuthenticatedMember(1L, "nickname");
-        AuthenticatedMember member2 = new AuthenticatedMember(2L, "nickname");
+        AuthenticatedMember member1 = new AuthenticatedMember(1L, "nickname", MemberRole.user);
+        AuthenticatedMember member2 = new AuthenticatedMember(2L, "nickname", MemberRole.user);
 
         // then
         Assertions.assertThat(member1.equals(member2)).isFalse();
@@ -21,8 +22,8 @@ class AuthenticatedMemberTest {
     @DisplayName("AuthenticatedMember hashCode 테스트")
     void hashCodeTest() {
         // given
-        AuthenticatedMember member1 = new AuthenticatedMember(1L, "nickname");
-        AuthenticatedMember member2 = new AuthenticatedMember(1L, "nickname");
+        AuthenticatedMember member1 = new AuthenticatedMember(1L, "nickname", MemberRole.manager);
+        AuthenticatedMember member2 = new AuthenticatedMember(1L, "nickname", MemberRole.manager);
 
         // then
         Assertions.assertThat(member1.hashCode()).isEqualTo(member2.hashCode());


### PR DESCRIPTION
## Issue Number
Resolves #9


## 변경사항
- 로그인 성공, 실패 핸들러 구현
- 인증객체 AuthenticatedMember role 필드 추가
![image](https://github.com/CatDesignProject/CUKZ-BE/assets/54367532/d3d9b2b4-dc6a-4340-97e5-2f29bd50f73b)


## PR Checklist
Pull Request가 다음을 만족하는지 확인해주세요.
- [x]  커밋 메시지가 “유형: [#이슈넘버] 메시지” 가이드라인을 준수합니다.
- [x]  추가, 수정사항에 대한 테스트를 완료했습니다. (feat & bugfix)
