### PR TITLE
feat: [#11] Validation DTO 검증오류 필드 모두 반환하도록 추가

### DIFF
--- a/src/main/java/com/example/common/exception/ExceptionResponseDto.java
+++ b/src/main/java/com/example/common/exception/ExceptionResponseDto.java
@@ -3,19 +3,21 @@ package com.example.common.exception;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+import java.util.List;
+
 @Getter
 public class ExceptionResponseDto {
 
     private final HttpStatus status;
-    private final String msg;
+    private final Object msg;
 
     public ExceptionResponseDto(BaseErrorCode errorCode) {
         this.status = errorCode.getStatus();
         this.msg = errorCode.getMsg();
     }
 
-    public ExceptionResponseDto(HttpStatus status, String msg) {
+    public ExceptionResponseDto(HttpStatus status, List<ValidationErrorResponseDto> validationErrors) {
         this.status = status;
-        this.msg = msg;
+        this.msg = validationErrors;
     }
 }

--- a/src/main/java/com/example/common/exception/GlobalExceptionController.java
+++ b/src/main/java/com/example/common/exception/GlobalExceptionController.java
@@ -3,10 +3,12 @@ package com.example.common.exception;
 import com.example.common.global.BaseResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @ControllerAdvice
 public class GlobalExceptionController {
@@ -24,9 +26,11 @@ public class GlobalExceptionController {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<BaseResponse<Object>> handleValidException(MethodArgumentNotValidException e) {
 
-        BindingResult bindingResult = e.getBindingResult();
-        String msg = bindingResult.getFieldErrors().get(0).getDefaultMessage();
-        ExceptionResponseDto responseDto = new ExceptionResponseDto(HttpStatus.BAD_REQUEST, msg);
+        List<ValidationErrorResponseDto> validationErrorResponseDtos = e.getAllErrors().stream().map
+                (objectError -> new ValidationErrorResponseDto(objectError))
+                .collect(Collectors.toList());
+
+        ExceptionResponseDto responseDto = new ExceptionResponseDto(HttpStatus.BAD_REQUEST, validationErrorResponseDtos);
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/src/main/java/com/example/common/exception/ValidationErrorResponseDto.java
+++ b/src/main/java/com/example/common/exception/ValidationErrorResponseDto.java
@@ -1,0 +1,18 @@
+package com.example.common.exception;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+
+@Getter
+@NoArgsConstructor
+public class ValidationErrorResponseDto {
+    private String field;
+    private String msg;
+
+    public ValidationErrorResponseDto(ObjectError e) {
+        this.field = ((FieldError) e).getField();
+        this.msg = e.getDefaultMessage();
+    }
+}


### PR DESCRIPTION
## Issue Number
Resolves #11 


## 변경사항
- 유효성 검증 응답 DTO에 오류 필드를 모두 반환하도록 수정했습니다.
   ![image](https://github.com/CatDesignProject/CUKZ-BE/assets/54367532/8d02594a-0084-4064-8fa0-fd06225d5e18)



## PR Checklist
Pull Request가 다음을 만족하는지 확인해주세요.
- [x]  커밋 메시지가 “유형: [#이슈넘버] 메시지” 가이드라인을 준수합니다.
- [x]  추가, 수정사항에 대한 테스트를 완료했습니다. (feat & bugfix)
