### PR TITLE
feat: [#10] 총대 신청용 이메일 인증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE' //amazon s3
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
+    implementation 'org.springframework.boot:spring-boot-starter-mail:3.3.0'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/example/common/exception/BaseErrorCode.java
+++ b/src/main/java/com/example/common/exception/BaseErrorCode.java
@@ -54,8 +54,9 @@ public enum BaseErrorCode {
     NOT_YET_WRITE_REVIEW(FORBIDDEN, "아직 해당 상품은 리뷰 작성을 할 수 없습니다."),
 
     // Mail
-    INVALID_EMAIL(BAD_REQUEST, "이메일 형식이 올바르지 않습니다."),
-    MAIL_SEND_FAILED(INTERNAL_SERVER_ERROR, "메일 전송에 실패했습니다.");
+    ILLEGAL_EMAIL(BAD_REQUEST, "이메일 형식이 올바르지 않습니다."),
+    MAIL_SEND_FAILED(INTERNAL_SERVER_ERROR, "메일 전송에 실패했습니다."),
+    INVALID_EMAIL(BAD_REQUEST, "이메일 인증에 실패했습니다.");
 
     private final HttpStatus status;
     private final String msg;

--- a/src/main/java/com/example/common/exception/BaseErrorCode.java
+++ b/src/main/java/com/example/common/exception/BaseErrorCode.java
@@ -51,7 +51,11 @@ public enum BaseErrorCode {
     UNAUTHORIZED_WRITE_REVIEW_TO_SELLER(FORBIDDEN, "해당 총대에게 리뷰를 작성할 권한이 없습니다."),
     UNAUTHORIZED_WRITE_REVIEW_FROM_PURCHASE_FORM(FORBIDDEN, "해당 구매폼으로 리뷰를 작성할 권한이 없습니다."),
     ALREADY_WRITE_REVIEW(FORBIDDEN, "이미 리뷰를 작성했습니다."),
-    NOT_YET_WRITE_REVIEW(FORBIDDEN, "아직 해당 상품은 리뷰 작성을 할 수 없습니다.");
+    NOT_YET_WRITE_REVIEW(FORBIDDEN, "아직 해당 상품은 리뷰 작성을 할 수 없습니다."),
+
+    // Mail
+    INVALID_EMAIL(BAD_REQUEST, "이메일 형식이 올바르지 않습니다."),
+    MAIL_SEND_FAILED(INTERNAL_SERVER_ERROR, "메일 전송에 실패했습니다.");
 
     private final HttpStatus status;
     private final String msg;

--- a/src/main/java/com/example/common/jwt/JwtTokenizer.java
+++ b/src/main/java/com/example/common/jwt/JwtTokenizer.java
@@ -1,0 +1,42 @@
+package com.example.common.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Component
+public class JwtTokenizer {
+
+    SecretKey key;
+
+    public JwtTokenizer() {
+        this.key = Jwts.SIG.HS256.key().build();
+    }
+
+    public String createToken(Long memberId, String email) {
+        long expMillis = System.currentTimeMillis() + 600000;
+
+        String jwt = Jwts.builder()
+                .expiration((new Date(expMillis)))
+                .claim("email", email)
+                .claim("memberId", memberId)
+                .signWith(key)
+                .compact();
+
+        return jwt;
+    }
+
+    public Claims parseToken(String jwt) {
+
+        Claims claims = Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(jwt)
+                .getPayload();
+
+        return claims;
+    }
+}

--- a/src/main/java/com/example/common/mail/CustomMailSender.java
+++ b/src/main/java/com/example/common/mail/CustomMailSender.java
@@ -1,0 +1,54 @@
+package com.example.common.mail;
+
+import com.example.common.exception.BaseErrorCode;
+import com.example.common.exception.GlobalException;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+import java.util.Map;
+
+@Component
+public class CustomMailSender {
+
+    private final SpringTemplateEngine templateEngine;
+    private final JavaMailSender javaMailSender;
+
+    public CustomMailSender(SpringTemplateEngine templateEngine, JavaMailSender javaMailSender) {
+        this.templateEngine = templateEngine;
+        this.javaMailSender = javaMailSender;
+    }
+
+    public boolean sendMail(String email, MailType type, Map<String, String> emailValues) {
+        String template = makeTemplate(type, emailValues);
+        return sendMail(email, template, type.getTitle());
+    }
+
+    // 메일 본문 HTML을 생성한다.
+    private String makeTemplate(MailType type, Map<String, String> emailValues) {
+        Context context = new Context();
+        emailValues.forEach((key, value) -> context.setVariable(key, value.toString()));
+        return templateEngine.process(type.getPath(), context);
+    }
+
+    // 메일을 발송한다.
+    private boolean sendMail(String email, String template, String title) {
+        MimeMessage message = javaMailSender.createMimeMessage();
+
+        try {
+            MimeMessageHelper helper = new MimeMessageHelper(message, true);
+            helper.setTo(email);
+            helper.setSubject(title);
+            helper.setText(template, true);
+        } catch (MessagingException e) {
+            throw new GlobalException(BaseErrorCode.MAIL_SEND_FAILED);
+        }
+
+        javaMailSender.send(message);
+        return true;
+    }
+}

--- a/src/main/java/com/example/common/mail/MailType.java
+++ b/src/main/java/com/example/common/mail/MailType.java
@@ -1,0 +1,17 @@
+package com.example.common.mail;
+
+import lombok.Getter;
+
+@Getter
+public enum MailType {
+    VERIFY_EMAIL("verify-email","[CUKZ] 총대 신청 인증 메일"),
+    CHANGE_PASSWORD("change-password", "[CUKZ] 비밀번호 변경 인증 메일");
+
+    private String path;
+    private String title;
+
+    MailType(String path, String title) {
+        this.path = path;
+        this.title = title;
+    }
+}

--- a/src/main/java/com/example/member/controller/MemberController.java
+++ b/src/main/java/com/example/member/controller/MemberController.java
@@ -3,8 +3,10 @@ package com.example.member.controller;
 import com.example.common.global.PageResponseDto;
 import com.example.member.dto.MemberRegisterRequestDto;
 import com.example.member.dto.MemberResponseDto;
+import com.example.member.dto.VerifyMailDto;
 import com.example.member.dto.VerifyUsernameDto;
 import com.example.member.service.MemberService;
+import com.example.member.service.MemberVerifyMailService;
 import com.example.security.authentication.AuthenticatedMember;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
     private final MemberService memberService;
+    private final MemberVerifyMailService memberVerifyMailService;
 
     @PostMapping("/members/register")
     public ResponseEntity<String> registerMember(@RequestBody @Validated MemberRegisterRequestDto memberRegisterRequestDto) {
@@ -48,5 +51,11 @@ public class MemberController {
         Page<MemberResponseDto> memberResponseDtos = memberService.getAllMembers(page - 1, size);
 
         return ResponseEntity.ok().body(PageResponseDto.toResponseDto(memberResponseDtos));
+    }
+
+    @PostMapping("/members/verify-email")
+    public ResponseEntity<Boolean> verifyMail(@RequestBody @Validated VerifyMailDto verifyMailDto) {
+        boolean isRequested = memberVerifyMailService.requestVerification(verifyMailDto);
+        return ResponseEntity.ok().body(isRequested);
     }
 }

--- a/src/main/java/com/example/member/controller/MemberController.java
+++ b/src/main/java/com/example/member/controller/MemberController.java
@@ -14,11 +14,15 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 @Slf4j
-@RestController
+@Controller
 @RequiredArgsConstructor
 public class MemberController {
 
@@ -57,5 +61,12 @@ public class MemberController {
     public ResponseEntity<Boolean> verifyMail(@RequestBody @Validated VerifyMailDto verifyMailDto) {
         boolean isRequested = memberVerifyMailService.requestVerification(verifyMailDto);
         return ResponseEntity.ok().body(isRequested);
+    }
+
+    @GetMapping("/verify-email")
+    public String verifyMail(@RequestParam String token, Model model) {
+        Map<String, String> map = memberVerifyMailService.verify(token);
+        model.addAllAttributes(map);
+        return "email-verification-complete";
     }
 }

--- a/src/main/java/com/example/member/dto/VerifyMailDto.java
+++ b/src/main/java/com/example/member/dto/VerifyMailDto.java
@@ -1,0 +1,17 @@
+package com.example.member.dto;
+
+import jakarta.validation.constraints.Email;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class VerifyMailDto {
+
+    @Email
+    private String email;
+
+    public VerifyMailDto(String email) {
+        this.email = email;
+    }
+}

--- a/src/main/java/com/example/member/entity/Member.java
+++ b/src/main/java/com/example/member/entity/Member.java
@@ -43,6 +43,11 @@ public class Member {
         this.nickname = nickname;
     }
 
+    public void promoteManager(String email) {
+        this.email = email;
+        this.role = MemberRole.manager;
+    }
+
     @Builder
     private Member(String username, String password, String nickname) {
         this.username = username;

--- a/src/main/java/com/example/member/service/MemberVerifyMailService.java
+++ b/src/main/java/com/example/member/service/MemberVerifyMailService.java
@@ -1,25 +1,28 @@
 package com.example.member.service;
 
 import com.example.common.jwt.JwtTokenizer;
+import com.example.common.mail.CustomMailSender;
+import com.example.common.mail.MailType;
 import com.example.member.dto.VerifyMailDto;
 import com.example.security.authentication.AuthenticatedMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Service
 @RequiredArgsConstructor
 public class MemberVerifyMailService {
 
     private final JwtTokenizer jwtTokenizer;
+    private final CustomMailSender customMailSender;
     private final String domain = "http://3.35.203.198:8080?token=";
 
     public boolean requestVerification(VerifyMailDto verifyMailDto) {
         String verificationLink = createVerificationLink(verifyMailDto.getEmail());
-        System.out.println(verificationLink);
-        String mailTemplate = createMailTemplate(verificationLink);
-        sendEmail(mailTemplate);
-        return false;
+        return sendMail(verifyMailDto.getEmail(), verificationLink);
     }
 
     public boolean verify() {
@@ -28,17 +31,18 @@ public class MemberVerifyMailService {
     }
 
     private String createVerificationLink(String email) { // memberId, email 으로 JWT 토큰 생성 및 메일 인증링크 생성
-        Long memberId = ((AuthenticatedMember) (SecurityContextHolder.getContext().getAuthentication().getPrincipal())).getMemberId();
-        String jwt = jwtTokenizer.createToken(memberId, email);
+        AuthenticatedMember member = (AuthenticatedMember) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String jwt = jwtTokenizer.createToken(member.getMemberId(), email);
         return domain + jwt;
     }
 
-    private String createMailTemplate(String link) {
-        // 인증 링크 포함한 이메일 문서 생성
-        return "";
-    }
+    private boolean sendMail(String email, String link) { // 이메일 발송
+        AuthenticatedMember member = (AuthenticatedMember) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Map<String, String> emailValues = new HashMap<>();
 
-    private void sendEmail(String mail) {
-        // 이메일 발송
+        emailValues.put("nickname", member.getNickName());
+        emailValues.put("verificationLink", link);
+
+        return customMailSender.sendMail(email, MailType.VERIFY_EMAIL, emailValues);
     }
 }

--- a/src/main/java/com/example/member/service/MemberVerifyMailService.java
+++ b/src/main/java/com/example/member/service/MemberVerifyMailService.java
@@ -1,0 +1,38 @@
+package com.example.member.service;
+
+import com.example.member.dto.VerifyMailDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberVerifyMailService {
+
+    public boolean requestVerification(VerifyMailDto verifyMailDto) {
+        String verificationLink = createVerificationLink(verifyMailDto.getEmail());
+        String mailTemplate = createMailTemplate(verificationLink);
+        sendEmail(mailTemplate);
+        return false;
+    }
+
+    public boolean verify() {
+        // 메일 인증 링크 토큰 검증
+        return false;
+    }
+
+    private String createVerificationLink(String email) {
+        // SecurityContext에서 memberId 꺼내기
+        // JWT 토큰 생성 시 memberId, email 넘겨주기
+        // 토큰 Redis에 저장하기
+        return ""; // 링크에 JWT 이어붙여 리턴
+    }
+
+    private String createMailTemplate(String link) {
+        // 인증 링크 포함한 이메일 문서 생성
+        return "";
+    }
+
+    private void sendEmail(String mail) {
+        // 이메일 발송
+    }
+}

--- a/src/main/java/com/example/member/service/MemberVerifyMailService.java
+++ b/src/main/java/com/example/member/service/MemberVerifyMailService.java
@@ -1,15 +1,22 @@
 package com.example.member.service;
 
+import com.example.common.jwt.JwtTokenizer;
 import com.example.member.dto.VerifyMailDto;
+import com.example.security.authentication.AuthenticatedMember;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class MemberVerifyMailService {
 
+    private final JwtTokenizer jwtTokenizer;
+    private final String domain = "http://3.35.203.198:8080?token=";
+
     public boolean requestVerification(VerifyMailDto verifyMailDto) {
         String verificationLink = createVerificationLink(verifyMailDto.getEmail());
+        System.out.println(verificationLink);
         String mailTemplate = createMailTemplate(verificationLink);
         sendEmail(mailTemplate);
         return false;
@@ -20,11 +27,10 @@ public class MemberVerifyMailService {
         return false;
     }
 
-    private String createVerificationLink(String email) {
-        // SecurityContext에서 memberId 꺼내기
-        // JWT 토큰 생성 시 memberId, email 넘겨주기
-        // 토큰 Redis에 저장하기
-        return ""; // 링크에 JWT 이어붙여 리턴
+    private String createVerificationLink(String email) { // memberId, email 으로 JWT 토큰 생성 및 메일 인증링크 생성
+        Long memberId = ((AuthenticatedMember) (SecurityContextHolder.getContext().getAuthentication().getPrincipal())).getMemberId();
+        String jwt = jwtTokenizer.createToken(memberId, email);
+        return domain + jwt;
     }
 
     private String createMailTemplate(String link) {

--- a/src/main/java/com/example/member/service/MemberVerifyMailService.java
+++ b/src/main/java/com/example/member/service/MemberVerifyMailService.java
@@ -1,13 +1,19 @@
 package com.example.member.service;
 
+import com.example.common.exception.BaseErrorCode;
+import com.example.common.exception.GlobalException;
 import com.example.common.jwt.JwtTokenizer;
 import com.example.common.mail.CustomMailSender;
 import com.example.common.mail.MailType;
 import com.example.member.dto.VerifyMailDto;
+import com.example.member.entity.Member;
+import com.example.member.repository.MemberRepository;
 import com.example.security.authentication.AuthenticatedMember;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -18,16 +24,32 @@ public class MemberVerifyMailService {
 
     private final JwtTokenizer jwtTokenizer;
     private final CustomMailSender customMailSender;
-    private final String domain = "http://3.35.203.198:8080?token=";
+    private final MemberRepository memberRepository;
+    private final String domain = "http://3.35.203.198:8080/verify-email?token=";
 
     public boolean requestVerification(VerifyMailDto verifyMailDto) {
         String verificationLink = createVerificationLink(verifyMailDto.getEmail());
         return sendMail(verifyMailDto.getEmail(), verificationLink);
     }
 
-    public boolean verify() {
-        // 메일 인증 링크 토큰 검증
-        return false;
+    public Map<String, String> verify(String token) { // 메일 인증 링크 토큰 검증
+        Map<String, String> map = new HashMap<>();
+        Claims claims;
+
+        try {
+            claims = jwtTokenizer.parseToken(token);
+        } catch (Exception e) {
+            throw new GlobalException(BaseErrorCode.INVALID_EMAIL);
+        }
+
+        String email = (String) claims.get("email");
+        Long memberId = Long.valueOf(String.valueOf(claims.get("memberId")));
+
+        String nickname = promoteManager(memberId, email);
+        map.put("email", email);
+        map.put("nickname", nickname);
+
+        return map;
     }
 
     private String createVerificationLink(String email) { // memberId, email 으로 JWT 토큰 생성 및 메일 인증링크 생성
@@ -44,5 +66,13 @@ public class MemberVerifyMailService {
         emailValues.put("verificationLink", link);
 
         return customMailSender.sendMail(email, MailType.VERIFY_EMAIL, emailValues);
+    }
+
+    @Transactional
+    protected String promoteManager(Long memberId, String email) { // 총대 승격
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new GlobalException(BaseErrorCode.NOT_FOUND_MEMBER));
+        member.promoteManager(email);
+        memberRepository.save(member);
+        return member.getNickname();
     }
 }

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -19,6 +19,21 @@ spring:
           format_sql: true
           dialect: org.hibernate.dialect.H2Dialect
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: cukz.official@gmail.com
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        transport:
+          protocol: smtp
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+        debug: true
+
 cloud:
   aws:
     s3:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,19 @@ spring:
     password: ENC(6QBAQWBB9UhtlwFSObzzwzFCCHjPC0C66MjuUvRLXV8=)
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: cukz.official@gmail.com
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+    protocol: smtp
+
 cloud:
   aws:
     s3:

--- a/src/main/resources/templates/email-verification-complete.html
+++ b/src/main/resources/templates/email-verification-complete.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/html">
+<head>
+    <title th:remove="all">[CUKZ] 이메일 인증 완료</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+</head>
+<body>
+<h3>[CUKZ] 이메일 인증 완료</h3>
+<p>
+    감사합니다! <span th:text="${nickname}">nickname</span>님의 이메일(<span th:text="${email}">email</span>) 인증이 완료되어 총대로 승격되었습니다.
+</p>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/verify-email.html
+++ b/src/main/resources/templates/verify-email.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/html">
+<head>
+    <title th:remove="all">[CUKZ] 총대 신청 인증 메일</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+</head>
+<body>
+<h3>[CUKZ] 총대 신청 인증 메일</h3>
+<p>
+    안녕하세요, <span th:text="${nickname}">nickname</span>님! 아래의 링크를 눌러 인증을 진행해주세요.
+</p>
+<p>
+    <span th:text="${verificationLink}">link</span>
+</p>
+</form>
+</body>
+</html>

--- a/src/test/java/com/example/common/jwt/JwtTokenizerTest.java
+++ b/src/test/java/com/example/common/jwt/JwtTokenizerTest.java
@@ -1,0 +1,33 @@
+package com.example.common.jwt;
+
+import io.jsonwebtoken.Claims;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class JwtTokenizerTest {
+
+    JwtTokenizer jwtTokenizer = new JwtTokenizer();
+
+    @Test
+    void test() {
+        // given - memberId, email & encrypt
+        Long memberId = 1L;
+        String email = "email@email.com";
+
+        // when - encrypt -> parse
+        String jwt = jwtTokenizer.createToken(memberId, email);
+        Claims claims = jwtTokenizer.parseToken(jwt);
+
+        // then - memberId & email == parse ?
+        Long findMemberId = claims.get("memberId", Long.class);
+        String findEmail = claims.get("email", String.class);
+
+        Assertions.assertThat(findMemberId).isEqualTo(memberId);
+        Assertions.assertThat(findEmail).isEqualTo(email);
+
+        System.out.println("exp: " + claims.getExpiration());
+        System.out.println("memberId: " + findMemberId);
+        System.out.println("email: " + findEmail);
+    }
+
+}


### PR DESCRIPTION
## Issue Number
Resolves #10 


## 변경사항
- `JwtTokenizer` : JWT 토큰 생성, 검증 클래스 구현
- `MemberVerifyEmailService` : 이메일 인증 서비스 구현
- `CustomMailSender` : 이메일 발송 클래스 구현

1. 인증용 메일 발송
   ![image](https://github.com/CatDesignProject/CUKZ-BE/assets/54367532/0f0c418b-7e9f-424c-aa8f-e96d3e6698e0)

2. 링크 클릭 시 화면
   ![image](https://github.com/CatDesignProject/CUKZ-BE/assets/54367532/c3892886-9796-41ce-814a-aea48007f32b)

3. 링크 클릭 후 DB
   ![image](https://github.com/CatDesignProject/CUKZ-BE/assets/54367532/f060a13e-e9e6-4b21-9cc5-e7c6416b196d)


## PR Checklist
Pull Request가 다음을 만족하는지 확인해주세요.
- [x]  커밋 메시지가 “유형: [#이슈넘버] 메시지” 가이드라인을 준수합니다.
- [x]  추가, 수정사항에 대한 테스트를 완료했습니다. (feat & bugfix)
